### PR TITLE
Adding decimal support to scale field

### DIFF
--- a/renamelayers/host/RenameLayers.jsx
+++ b/renamelayers/host/RenameLayers.jsx
@@ -225,7 +225,7 @@ LayerOperations.prototype.setSelectedLayerSuffix = function( scale, resize, suff
             foundLeadingDigits = true;
         }
         if (foundLeadingDigits)
-            while ((i < s.length) && (isDigit(s[i]) || (s[i] in {'%':1, 'x':1, '%':1, ' ':1}))) {
+            while ((i < s.length) && (isDigit(s[i]) || (s[i] in {'.':1, '%':1, 'x':1, '%':1, ' ':1}))) {
                 i++;
                 foundScaleSize = true;
             }

--- a/renamelayers/js/renamelayers.js
+++ b/renamelayers/js/renamelayers.js
@@ -140,8 +140,9 @@ function getParams() {
     var suffix = $("#suffixmenu").val();
     if (suffix == ".png") suffix += $("#pngdepth").val();
     if (suffix == ".jpg") suffix += $("#jpgqual").val();
-    
-    var scaleTxt = (suffix != "") ? $("#scalevalue").val() + "%" : "100%";
+    var scaleNum = $("#scalevalue").val();
+    scaleNum = Math.round(scaleNum*100)/100;
+    var scaleTxt = (suffix != "") ? scaleNum + "%" : "100%";
     var resizeTxt = "";
     if ((suffix != "") && $("#resize").is(":checked")
         && hasText("#resizeX") && hasText("#resizeY"))

--- a/renamelayers/renamelayers.html
+++ b/renamelayers/renamelayers.html
@@ -73,7 +73,7 @@
         <input type="checkbox" name="scale" id="scale">
         <span data-locale="rename-scale-checkbox" id="sclspan">Scale</span>
     </label>
-    <input style="margin-left:24px;" id="scalevalue" class="ccstyle" type="text" size="4" maxlength="4" role="textbox" value="100" disabled />%
+    <input style="margin-left:24px;" id="scalevalue" class="ccstyle" type="text" size="4" maxlength="8" role="textbox" value="100" disabled />%
 </div>
 <div style="margin-top:3px; margin-bottom:0px">
 	<label id="resizechklabel" for="resize">


### PR DESCRIPTION
Adding in expanded decimal support for 'Scale' field. I was working in a
large pixel count file and trying to scale down to get a very specific
screen res on layers with varying bounding boxes and found that things
like 35.65% were only partially supported... Thought I could contribute the update I applied, if it seems to pass muster.

Issue:
The character limit is 4, so '105.5' is stops at '105.'
Fix:
Raise the limit to 8 char max.

Issue:
More than two decimal places seems to make the Generator grumpy.
Fix:
Round to nearest two decimals when get/setting params.

Issue:
Removing percentages with decimals in the layer names is broken. Stops
the name grep at the '.' and renames the layer with the remaining
decimal number instead of the base name
Fix:
Add '.' into the allowed characters in the check for foundScaleSize in
parseName()