### PR TITLE
Handle multi-line ExtensionManifest element

### DIFF
--- a/installPanels.py
+++ b/installPanels.py
@@ -65,10 +65,10 @@ PSexePath = psAppFolder + {"win32":"Photoshop.exe",
 
 # Extract the panel ID and name from the Manifest file
 def getExtensionInfo(manifestPath):
-    extInfo = [s for s in open(manifestPath,'r').readlines() if re.match("^<ExtensionManifest.*", s)]
-    if (len(extInfo) > 0):
-        extInfo = extInfo[0]
-        return extInfo
+    extensionManifest = xml.dom.minidom.parse(manifestPath).getElementsByTagName("ExtensionManifest")[0]
+
+    if extensionManifest:
+        return ''.join('{}="{}" '.format(key, val) for key, val in extensionManifest.attributes.items())
     else:
         print "# No ExtensionManifest for %s" % manifestPath
         return None


### PR DESCRIPTION
Use xml.dom.minidom to parse the ExtensionManifest element
when extracting the panel ID and name from the manifest.xml file.
By doing it this way we no longer require that the attributes are
in a single line.

Fixes #27
